### PR TITLE
[Issue #25] Add PGP block stripping for Grok multi-agent

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,20 @@ import { injectXMLToolInstructions } from './xml-tool-formatter.js'
 import { parseAssistantMessage } from './xml-tool-parser.js'
 import { redactSecrets } from './utils/redaction.js'
 
+// PGP block stripping for Grok multi-agent responses
+const PGP_BLOCK_PATTERN = /-----BEGIN PGP MESSAGE-----[\s\S]*?-----END PGP MESSAGE-----/g
+
+/**
+ * Strip PGP armored blocks from text content.
+ * Used for Grok multi-agent responses that include encrypted sub-agent state.
+ * @param {string} text - Text that may contain PGP blocks
+ * @returns {string} - Clean text with PGP blocks removed
+ */
+function stripPgpBlocks(text) {
+  if (!text || typeof text !== 'string') return text
+  return text.replace(PGP_BLOCK_PATTERN, '').trim()
+}
+
 let packageVersion = '0.0.0'
 let packageDir = null
 
@@ -1299,6 +1313,11 @@ fastify.post('/v1/messages', async (request, reply) => {
       const choice = data.choices[0]
       const openaiMessage = choice.message
 
+      // Strip PGP blocks from Grok multi-agent responses
+      if (provider === 'grok' && selectedModel.includes('multi-agent')) {
+        openaiMessage.content = stripPgpBlocks(openaiMessage.content)
+      }
+
       // Map finish_reason to anthropic stop_reason.
       const stopReason = mapStopReason(choice.finish_reason)
       
@@ -1482,6 +1501,10 @@ fastify.post('/v1/messages', async (request, reply) => {
                   debug('[Streaming] Could not parse buffered data, discarding:', chunkBuffer.substring(0, 100))
                 }
                 chunkBuffer = ''
+              }
+              // Strip PGP blocks from Grok multi-agent streaming responses
+              if (provider === 'grok' && selectedModel.includes('multi-agent')) {
+                accumulatedContent = stripPgpBlocks(accumulatedContent)
               }
               const trimmedContent = accumulatedContent.trim()
               const trimmedReasoning = accumulatedReasoning.trim()


### PR DESCRIPTION
## Summary
- Add PGP block stripping for Grok multi-agent responses
- Strip PGP-armored encrypted sub-agent state blocks before returning to client

## Changes
- Add PGP_BLOCK_PATTERN regex for detecting armored PGP blocks
- Add stripPgpBlocks() function to remove PGP blocks from text content
- Apply stripping in non-streaming response processing
- Apply stripping in streaming response accumulation
- Only active when provider is 'grok' and model includes 'multi-agent'

## Acceptance Criteria
- [x] PGP blocks with BEGIN PGP MESSAGE / END PGP MESSAGE delimiters are stripped
- [x] Normal content without PGP blocks passes through unchanged
- [x] Empty/null input is handled gracefully
- [x] Both streaming and non-streaming responses are handled
- [x] node --check index.js passes

## Test Plan
- [x] node --check index.js passes
- [ ] Manual test with Grok multi-agent API key (requires API access)

Closes #25